### PR TITLE
Suggested type updates

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@
 
 export type Endpoint = 'countries' | 'holidays' | 'languages' | 'workday' | 'workdays';
 
-type Weekday = {
+export type Weekday = {
   name: 'Monday' | 'Tuesday' | 'Wednesday' | 'Thursday' | 'Friday' | 'Saturday' | 'Sunday';
   numeric: 1 | 2 | 3 | 4 | 5 | 6 | 7;
 };
@@ -55,7 +55,7 @@ export type WorkdaysRequest = Request & {
 export type Response = {
   requests: {
     available: number;
-    resets: Date;
+    resets: string;
     used: number;
   };
   status: number;
@@ -88,9 +88,9 @@ export type CountriesResponse = Response & {
 export type HolidaysResponse = Response & {
   holidays?: {
     country: string;
-    date: Date;
+    date: string;
     name: string;
-    observed: Date;
+    observed: string;
     public: boolean;
     uuid: string;
     subdivisions?: string[];
@@ -106,7 +106,7 @@ export type LanguagesResponse = Response & {
 
 export type WorkdayResponse = Response & {
   workday?: {
-    date: Date;
+    date: string;
     weekday: Weekday;
   }
 };


### PR DESCRIPTION
Two suggestions in this PR:
- Export of the Weekday type. When we write tests we would like for it to be available and currently we are re-declaring it.
- The dates in the responses are typed as Date objects but they come back as strings. That is no problem in some cases, but we have a small use case where we need to examine the date before returning the response. We want to include a few custom holidays as well. This means i can't really parse the string without getting type errors, i also can't really use the string as a Date for obvious reasons.

Hope to hear your view on this :)

From a response:
{ date: '2021-12-24', weekday: { name: 'Friday', numeric: '5' } }