### PR TITLE
refactor: remove unnecessary imports

### DIFF
--- a/dist/holidayapi.js
+++ b/dist/holidayapi.js
@@ -48,8 +48,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.HolidayAPI = void 0;
-var node_fetch_1 = require("node-fetch");
-var url_1 = require("url");
 var HolidayAPI = (function () {
     function HolidayAPI(_a) {
         var key = _a.key, _b = _a.version, version = _b === void 0 ? 1 : _b;
@@ -69,8 +67,8 @@ var HolidayAPI = (function () {
     }
     HolidayAPI.prototype.createUrl = function (endpoint, request) {
         var parameters = __assign({ key: this.key }, request);
-        var url = new url_1.URL(endpoint, this.baseUrl);
-        url.search = new url_1.URLSearchParams(parameters).toString();
+        var url = new URL(endpoint, this.baseUrl);
+        url.search = new URLSearchParams(parameters).toString();
         return url.toString();
     };
     HolidayAPI.prototype.request = function (endpoint, request) {
@@ -78,7 +76,7 @@ var HolidayAPI = (function () {
             var response, payload, err_1;
             return __generator(this, function (_a) {
                 switch (_a.label) {
-                    case 0: return [4, (0, node_fetch_1.default)(this.createUrl(endpoint, request))];
+                    case 0: return [4, fetch(this.createUrl(endpoint, request))];
                     case 1:
                         response = _a.sent();
                         _a.label = 2;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "holidayapi",
       "version": "7.0.0",
       "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      },
       "devDependencies": {
         "@types/jest": "^29.5.6",
         "@types/nock": "^11.1.0",
@@ -4795,25 +4792,6 @@
         "node": ">= 10.13"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5805,11 +5783,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -6111,20 +6084,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
   },
-  "dependencies": {
-    "node-fetch": "^2.7.0"
-  },
   "scripts": {
     "build": "tsc",
     "lint": "eslint --ext .js,.ts src tests",

--- a/src/holidayapi.ts
+++ b/src/holidayapi.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fetch from 'node-fetch';
-import { URL, URLSearchParams } from 'url';
 import {
   CountriesRequest,
   CountriesResponse,


### PR DESCRIPTION
This library requires Node.js >= 18, so you can use global `fetch`. `URL` and `URLSearchParams` are also globally available.
By using them as global members, the library possibly works in other runtimes like Deno and Cloudflare Workers